### PR TITLE
Client-side navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "randomoscars.github.io",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5530,6 +5530,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -9161,6 +9169,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
+      }
     },
     "react-scripts": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
+    "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.3"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,10 +40,13 @@ function Layout() {
 
   useEffect(() => {
     setAwardData(undefined);
-    getAwardDataWithRetry(
-      Number(searchParams.get('category')),
-      Number(searchParams.get('year'))
-    ).then(setAwardData);
+    const categoryId = searchParams.get('category');
+    const year = searchParams.get('year');
+    if (typeof categoryId === 'string' && typeof year === 'string') {
+      getAwardDataWithRetry(Number(categoryId), Number(year)).then(
+        setAwardData
+      );
+    }
   }, [searchParams]);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { AppFooter, AppHeader, SiteExplainer } from './StaticComponents';
 import { EnrichedInfo, OscarCategory } from './Models';
 import { UserInputSection } from './UserInputSection';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useSearchParams } from 'react-router-dom';
 
 function App() {
   return (
@@ -35,11 +35,12 @@ function Layout() {
   const [awardData, setAwardData] = useState(
     undefined as undefined | OscarCategory
   );
+  const [searchParams, setSearchParams] = useSearchParams();
 
   return (
     <>
       <section>
-        <UserInputSection setAwardData={setAwardData} />
+        <UserInputSection setSearchParams={setSearchParams} />
       </section>
       <section>
         <NomineeHeader awardData={awardData} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AppFooter, AppHeader, SiteExplainer } from './StaticComponents';
 import { EnrichedInfo, OscarCategory } from './Models';
 import { UserInputSection } from './UserInputSection';
 import { Routes, Route, useSearchParams } from 'react-router-dom';
+import { getAwardDataWithRetry } from './Local.connector';
 
 function App() {
   return (
@@ -36,6 +37,14 @@ function Layout() {
     undefined as undefined | OscarCategory
   );
   const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    setAwardData(undefined);
+    getAwardDataWithRetry(
+      Number(searchParams.get('category')),
+      Number(searchParams.get('year'))
+    ).then(setAwardData);
+  }, [searchParams]);
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,10 @@ function Layout() {
   return (
     <>
       <section>
-        <UserInputSection setSearchParams={setSearchParams} />
+        <UserInputSection
+          searchParams={searchParams}
+          setSearchParams={setSearchParams}
+        />
       </section>
       <section>
         <NomineeHeader awardData={awardData} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,13 +111,25 @@ function Nominees(props: { awardData: OscarCategory | undefined }) {
               {hasFor && (
                 <td style={{ padding: '1rem' }}>
                   {candidate.for_enriched.map(n => {
-                    return <EnrichedLink nomineeData={n} won={candidate.won} />;
+                    return (
+                      <EnrichedLink
+                        nomineeData={n}
+                        won={candidate.won}
+                        key={n.imdb_id}
+                      />
+                    );
                   })}
                 </td>
               )}
               <td style={{ padding: '1rem' }}>
                 {candidate.target_enriched.map(n => {
-                  return <EnrichedLink nomineeData={n} won={candidate.won} />;
+                  return (
+                    <EnrichedLink
+                      nomineeData={n}
+                      won={candidate.won}
+                      key={n.imdb_id}
+                    />
+                  );
                 })}
               </td>
               {hasNotes && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,10 @@ function App() {
         height: '90vh',
       }}
     >
-      <Layout />
+      <div>
+        <AppHeader />
+        <Layout />
+      </div>
       <div>
         <section>
           <hr />
@@ -31,8 +34,7 @@ function Layout() {
   );
 
   return (
-    <div>
-      <AppHeader />
+    <>
       <section>
         <UserInputSection setAwardData={setAwardData} />
       </section>
@@ -40,7 +42,7 @@ function Layout() {
         <NomineeHeader awardData={awardData} />
         <Nominees awardData={awardData} />
       </section>
-    </div>
+    </>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,12 @@
 import React, { useState } from 'react';
-import { BsSearch, BsShuffle } from 'react-icons/bs';
-import { CategorySelect, IconButtonLabel, YearInput } from './FormInputs';
 import { AppFooter, AppHeader, SiteExplainer } from './StaticComponents';
 import { EnrichedInfo, OscarCategory } from './Models';
-import { getAwardDataWithRetry, randomize } from './Local.connector';
+import { UserInputSection } from './UserInputSection';
 
 function App() {
   const [awardData, setAwardData] = useState(
     undefined as undefined | OscarCategory
   );
-  const [category, setCategory] = useState<string | undefined>(undefined);
-  const [year, setYear] = useState<number | undefined>(undefined);
-
-  const search = (category: string, year: number) => {
-    setAwardData(undefined);
-    getAwardDataWithRetry(category, year)
-      .then(setAwardData)
-      .catch(() => {});
-  };
-
-  const randomizeForm = () => {
-    randomize().then(([randomCategory, randomYear]) => {
-      setCategory(randomCategory);
-      setYear(randomYear);
-      search(randomCategory, randomYear);
-    });
-  };
 
   return (
     <div
@@ -39,19 +20,7 @@ function App() {
       <div>
         <AppHeader />
         <section>
-          <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-            <CategorySelect category={category} setCategory={setCategory} />
-            <YearInput year={year} setYear={setYear} />
-            <button
-              onClick={() => search(category as string, year as number)}
-              disabled={!category || !year}
-            >
-              <IconButtonLabel label="Search" icon={BsSearch} />
-            </button>
-          </div>
-          <button onClick={() => randomizeForm()}>
-            <IconButtonLabel label="Randomize" icon={BsShuffle} />
-          </button>
+          <UserInputSection setAwardData={setAwardData} />
         </section>
         <section>
           <NomineeHeader awardData={awardData} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { AppFooter, AppHeader, SiteExplainer } from './StaticComponents';
 import { EnrichedInfo, OscarCategory } from './Models';
 import { UserInputSection } from './UserInputSection';
+import { Routes, Route } from 'react-router-dom';
 
 function App() {
   return (
@@ -15,7 +16,9 @@ function App() {
     >
       <div>
         <AppHeader />
-        <Layout />
+        <Routes>
+          <Route path="/" element={<Layout />} />
+        </Routes>
       </div>
       <div>
         <section>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,6 @@ import { EnrichedInfo, OscarCategory } from './Models';
 import { UserInputSection } from './UserInputSection';
 
 function App() {
-  const [awardData, setAwardData] = useState(
-    undefined as undefined | OscarCategory
-  );
-
   return (
     <div
       style={{
@@ -17,16 +13,7 @@ function App() {
         height: '90vh',
       }}
     >
-      <div>
-        <AppHeader />
-        <section>
-          <UserInputSection setAwardData={setAwardData} />
-        </section>
-        <section>
-          <NomineeHeader awardData={awardData} />
-          <Nominees awardData={awardData} />
-        </section>
-      </div>
+      <Layout />
       <div>
         <section>
           <hr />
@@ -34,6 +21,25 @@ function App() {
         </section>
         <AppFooter />
       </div>
+    </div>
+  );
+}
+
+function Layout() {
+  const [awardData, setAwardData] = useState(
+    undefined as undefined | OscarCategory
+  );
+
+  return (
+    <div>
+      <AppHeader />
+      <section>
+        <UserInputSection setAwardData={setAwardData} />
+      </section>
+      <section>
+        <NomineeHeader awardData={awardData} />
+        <Nominees awardData={awardData} />
+      </section>
     </div>
   );
 }

--- a/src/FormInputs.tsx
+++ b/src/FormInputs.tsx
@@ -38,7 +38,7 @@ export function YearInput(props: {
 
 export function CategorySelect(props: {
   categoryId: number | undefined;
-  setCategoryId: Dispatch<SetStateAction<number | undefined>>;
+  setCategoryId: Dispatch<SetStateAction<number>>;
 }) {
   const [categories, setCategories] = useState([] as OscarCategory[]);
 
@@ -55,9 +55,6 @@ export function CategorySelect(props: {
       defaultValue={undefined}
       style={{ width: '20rem', overflowX: 'hidden' }}
     >
-      <option value={undefined} disabled>
-        Category
-      </option>
       {categories.map(cat => (
         <option value={cat.category_id} key={cat.category_id}>
           {cat.normalized_name}

--- a/src/FormInputs.tsx
+++ b/src/FormInputs.tsx
@@ -1,6 +1,7 @@
 import { IconType } from 'react-icons';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { getAllCategories } from './Local.connector';
+import { OscarCategory } from './Models';
 
 export function IconButtonLabel(props: { label: string; icon: IconType }) {
   return (
@@ -36,10 +37,10 @@ export function YearInput(props: {
 }
 
 export function CategorySelect(props: {
-  categoryName: string | undefined;
-  setCategory: Dispatch<SetStateAction<string | undefined>>;
+  categoryId: number | undefined;
+  setCategoryId: Dispatch<SetStateAction<number | undefined>>;
 }) {
-  const [categories, setCategories] = useState([] as string[]);
+  const [categories, setCategories] = useState([] as OscarCategory[]);
 
   useEffect(() => {
     getAllCategories()
@@ -49,8 +50,8 @@ export function CategorySelect(props: {
 
   return (
     <select
-      value={props.categoryName}
-      onChange={e => props.setCategory(e.target.value)}
+      value={props.categoryId}
+      onChange={e => props.setCategoryId(Number(e.target.value))}
       defaultValue={undefined}
       style={{ width: '20rem', overflowX: 'hidden' }}
     >
@@ -58,8 +59,8 @@ export function CategorySelect(props: {
         Category
       </option>
       {categories.map(cat => (
-        <option value={cat} key={cat}>
-          {cat}
+        <option value={cat.category_id} key={cat.category_id}>
+          {cat.normalized_name}
         </option>
       ))}
     </select>

--- a/src/FormInputs.tsx
+++ b/src/FormInputs.tsx
@@ -36,7 +36,7 @@ export function YearInput(props: {
 }
 
 export function CategorySelect(props: {
-  category: string | undefined;
+  categoryName: string | undefined;
   setCategory: Dispatch<SetStateAction<string | undefined>>;
 }) {
   const [categories, setCategories] = useState([] as string[]);
@@ -49,7 +49,7 @@ export function CategorySelect(props: {
 
   return (
     <select
-      value={props.category}
+      value={props.categoryName}
       onChange={e => props.setCategory(e.target.value)}
       defaultValue={undefined}
       style={{ width: '20rem', overflowX: 'hidden' }}

--- a/src/Local.connector.ts
+++ b/src/Local.connector.ts
@@ -53,5 +53,6 @@ export async function randomize() {
   const oscarCategories = await getOscarCategories(ceremonyNum);
   const index = Math.floor(Math.random() * oscarCategories.length);
   const categoryName = oscarCategories[index].normalized_name;
-  return [categoryName, ceremonyNum + 1928] as const;
+  const categoryId = oscarCategories[index].category_id;
+  return [categoryId, categoryName, ceremonyNum + 1928] as const;
 }

--- a/src/Local.connector.ts
+++ b/src/Local.connector.ts
@@ -24,35 +24,32 @@ export async function getAllCategories(): Promise<OscarCategory[]> {
 }
 
 export async function getAwardDataWithRetry(
-  categoryName: string,
+  categoryId: number,
   year: number
 ): Promise<OscarCategory | undefined> {
-  const awardData = await getAwardData(categoryName, year);
+  const awardData = await getAwardData(categoryId, year);
   if (awardData) {
     return awardData;
   }
   if (year < 2021) {
-    return await getAwardDataWithRetry(categoryName, year + 1);
+    return await getAwardDataWithRetry(categoryId, year + 1);
   }
   return undefined;
 }
 
 export async function getAwardData(
-  categoryName: string,
+  categoryId: number,
   year: number
 ): Promise<OscarCategory | undefined> {
   const ceremonyNum = year - 1928;
   const oscarCategories = await getOscarCategories(ceremonyNum);
-  return oscarCategories.find(
-    category => category.normalized_name === categoryName
-  );
+  return oscarCategories.find(category => category.category_id === categoryId);
 }
 
 export async function randomize() {
   const ceremonyNum = Math.floor(Math.random() * 92) + 1;
   const oscarCategories = await getOscarCategories(ceremonyNum);
   const index = Math.floor(Math.random() * oscarCategories.length);
-  const categoryName = oscarCategories[index].normalized_name;
   const categoryId = oscarCategories[index].category_id;
-  return [categoryId, categoryName, ceremonyNum + 1928] as const;
+  return [categoryId, ceremonyNum + 1928] as const;
 }

--- a/src/Local.connector.ts
+++ b/src/Local.connector.ts
@@ -1,5 +1,5 @@
 import { OscarCategory, OscarYear } from './Models';
-import uniq from 'ramda/src/uniq';
+import uniqBy from 'ramda/src/uniqBy';
 
 async function getOscarCategories(ceremonyNum: number): Promise<OscarYear> {
   const fileResponse = await fetch(`/Data/${ceremonyNum}.json`);
@@ -12,15 +12,15 @@ async function getOscarCategories(ceremonyNum: number): Promise<OscarYear> {
   });
 }
 
-export async function getAllCategories(): Promise<string[]> {
-  let categories: string[] = [];
+export async function getAllCategories(): Promise<OscarCategory[]> {
+  let categories: OscarCategory[] = [];
   for (let i = 1; i <= 93; i++) {
     const oscarCategories = await getOscarCategories(i);
-    categories = categories.concat(
-      oscarCategories.map(category => category.normalized_name)
-    );
+    categories = categories.concat(oscarCategories);
   }
-  return uniq(categories).sort();
+  return uniqBy(cat => cat.normalized_name, categories).sort((a, b) =>
+    a.normalized_name > b.normalized_name ? 1 : -1
+  );
 }
 
 export async function getAwardDataWithRetry(

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -65,3 +65,6 @@ export type SearchParamsSetter = (
       }
     | undefined
 ) => void;
+
+export const DEFAULT_YEAR = undefined;
+export const DEFAULT_CATEGORY_ID = 13;

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -1,3 +1,5 @@
+import { URLSearchParamsInit } from 'react-router-dom';
+
 export const categories = [
   'Best Actor in a Leading Role',
   'Best Actor in a Supporting Role',
@@ -53,3 +55,13 @@ export type ImageInfo = {
   height: string;
   width: string;
 };
+
+export type SearchParamsSetter = (
+  nextInit: URLSearchParamsInit,
+  navigateOptions?:
+    | {
+        replace?: boolean | undefined;
+        state?: any;
+      }
+    | undefined
+) => void;

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -67,4 +67,4 @@ export type SearchParamsSetter = (
 ) => void;
 
 export const DEFAULT_YEAR = undefined;
-export const DEFAULT_CATEGORY_ID = 13;
+export const DEFAULT_CATEGORY_ID = 61; // Best Motion Picture of the Year

--- a/src/StaticComponents.tsx
+++ b/src/StaticComponents.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export function AppHeader() {
   return (
     <header className="App-header">
-      <h1>Random Oscars</h1>
+      <Link to="/">
+        <h1>Random Oscars</h1>
+      </Link>
     </header>
   );
 }

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -2,14 +2,18 @@ import { CategorySelect, IconButtonLabel, YearInput } from './FormInputs';
 import { BsSearch, BsShuffle } from 'react-icons/bs';
 import React, { useEffect, useState } from 'react';
 import { randomize } from './Local.connector';
-import { SearchParamsSetter } from './Models';
+import {
+  DEFAULT_CATEGORY_ID,
+  DEFAULT_YEAR,
+  SearchParamsSetter,
+} from './Models';
 
 export function UserInputSection(props: {
   searchParams: URLSearchParams;
   setSearchParams: SearchParamsSetter;
 }) {
-  const [categoryId, setCategoryId] = useState<number | undefined>(undefined);
-  const [year, setYear] = useState<number | undefined>(undefined);
+  const [categoryId, setCategoryId] = useState<number>(DEFAULT_CATEGORY_ID);
+  const [year, setYear] = useState<number | undefined>(DEFAULT_YEAR);
 
   const search = (categoryId: number, year: number) => {
     props.setSearchParams({
@@ -27,8 +31,10 @@ export function UserInputSection(props: {
   useEffect(() => {
     const categoryId = props.searchParams.get('category');
     if (typeof categoryId === 'string') setCategoryId(Number(categoryId));
+    else setCategoryId(DEFAULT_CATEGORY_ID);
     const year = props.searchParams.get('year');
     if (typeof year === 'string') setYear(Number(year));
+    else setYear(DEFAULT_YEAR);
   }, [props.searchParams]);
 
   return (

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -44,7 +44,7 @@ export function UserInputSection(props: {
         <YearInput year={year} setYear={setYear} />
         <button
           onClick={() => search(categoryId as number, year as number)}
-          disabled={!categoryId || !year}
+          disabled={typeof year !== 'number'}
         >
           <IconButtonLabel label="Search" icon={BsSearch} />
         </button>

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -1,26 +1,20 @@
 import { CategorySelect, IconButtonLabel, YearInput } from './FormInputs';
 import { BsSearch, BsShuffle } from 'react-icons/bs';
 import React, { useState } from 'react';
-import { getAwardDataWithRetry, randomize } from './Local.connector';
-import { OscarCategory } from './Models';
-import { useNavigate } from 'react-router-dom';
+import { randomize } from './Local.connector';
+import { SearchParamsSetter } from './Models';
 
 export function UserInputSection(props: {
-  setAwardData: React.Dispatch<React.SetStateAction<OscarCategory | undefined>>;
+  setSearchParams: SearchParamsSetter;
 }) {
   const [categoryId, setCategoryId] = useState<number | undefined>(undefined);
   const [year, setYear] = useState<number | undefined>(undefined);
-  const navigate = useNavigate();
 
   const search = (categoryId: number, year: number) => {
-    navigate({
-      pathname: '/',
-      search: `?category=${categoryId}&year=${year}`,
+    props.setSearchParams({
+      category: categoryId.toString(),
+      year: year.toString(),
     });
-    props.setAwardData(undefined);
-    getAwardDataWithRetry(categoryId, year)
-      .then(props.setAwardData)
-      .catch(() => {});
   };
 
   const randomizeForm = () => {

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -7,31 +7,39 @@ import { OscarCategory } from './Models';
 export function UserInputSection(props: {
   setAwardData: React.Dispatch<React.SetStateAction<OscarCategory | undefined>>;
 }) {
-  const [category, setCategory] = useState<string | undefined>(undefined);
+  const [categoryId, setCategoryId] = useState<number | undefined>(undefined);
+  const [categoryName, setCategoryName] = useState<string | undefined>(
+    undefined
+  );
   const [year, setYear] = useState<number | undefined>(undefined);
 
-  const search = (category: string, year: number) => {
+  const search = (categoryId: number, categoryName: string, year: number) => {
     props.setAwardData(undefined);
-    getAwardDataWithRetry(category, year)
+    getAwardDataWithRetry(categoryName, year)
       .then(props.setAwardData)
       .catch(() => {});
   };
 
   const randomizeForm = () => {
-    randomize().then(([randomCategory, randomYear]) => {
-      setCategory(randomCategory);
+    randomize().then(([randomCategoryId, randomCategoryName, randomYear]) => {
+      setCategoryName(randomCategoryName);
       setYear(randomYear);
-      search(randomCategory, randomYear);
+      search(randomCategoryId, randomCategoryName, randomYear);
     });
   };
   return (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <CategorySelect category={category} setCategory={setCategory} />
+        <CategorySelect
+          categoryName={categoryName}
+          setCategory={setCategoryName}
+        />
         <YearInput year={year} setYear={setYear} />
         <button
-          onClick={() => search(category as string, year as number)}
-          disabled={!category || !year}
+          onClick={() =>
+            search(categoryId as number, categoryName as string, year as number)
+          }
+          disabled={!categoryName || !year}
         >
           <IconButtonLabel label="Search" icon={BsSearch} />
         </button>

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -1,10 +1,11 @@
 import { CategorySelect, IconButtonLabel, YearInput } from './FormInputs';
 import { BsSearch, BsShuffle } from 'react-icons/bs';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { randomize } from './Local.connector';
 import { SearchParamsSetter } from './Models';
 
 export function UserInputSection(props: {
+  searchParams: URLSearchParams;
   setSearchParams: SearchParamsSetter;
 }) {
   const [categoryId, setCategoryId] = useState<number | undefined>(undefined);
@@ -19,11 +20,17 @@ export function UserInputSection(props: {
 
   const randomizeForm = () => {
     randomize().then(([randomCategoryId, randomYear]) => {
-      setCategoryId(randomCategoryId);
-      setYear(randomYear);
       search(randomCategoryId, randomYear);
     });
   };
+
+  useEffect(() => {
+    const categoryId = props.searchParams.get('category');
+    if (typeof categoryId === 'string') setCategoryId(Number(categoryId));
+    const year = props.searchParams.get('year');
+    if (typeof year === 'string') setYear(Number(year));
+  }, [props.searchParams]);
+
   return (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -1,0 +1,44 @@
+import { CategorySelect, IconButtonLabel, YearInput } from './FormInputs';
+import { BsSearch, BsShuffle } from 'react-icons/bs';
+import React, { useState } from 'react';
+import { getAwardDataWithRetry, randomize } from './Local.connector';
+import { OscarCategory } from './Models';
+
+export function UserInputSection(props: {
+  setAwardData: React.Dispatch<React.SetStateAction<OscarCategory | undefined>>;
+}) {
+  const [category, setCategory] = useState<string | undefined>(undefined);
+  const [year, setYear] = useState<number | undefined>(undefined);
+
+  const search = (category: string, year: number) => {
+    props.setAwardData(undefined);
+    getAwardDataWithRetry(category, year)
+      .then(props.setAwardData)
+      .catch(() => {});
+  };
+
+  const randomizeForm = () => {
+    randomize().then(([randomCategory, randomYear]) => {
+      setCategory(randomCategory);
+      setYear(randomYear);
+      search(randomCategory, randomYear);
+    });
+  };
+  return (
+    <>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        <CategorySelect category={category} setCategory={setCategory} />
+        <YearInput year={year} setYear={setYear} />
+        <button
+          onClick={() => search(category as string, year as number)}
+          disabled={!category || !year}
+        >
+          <IconButtonLabel label="Search" icon={BsSearch} />
+        </button>
+      </div>
+      <button onClick={() => randomizeForm()}>
+        <IconButtonLabel label="Randomize" icon={BsShuffle} />
+      </button>
+    </>
+  );
+}

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -8,23 +8,20 @@ export function UserInputSection(props: {
   setAwardData: React.Dispatch<React.SetStateAction<OscarCategory | undefined>>;
 }) {
   const [categoryId, setCategoryId] = useState<number | undefined>(undefined);
-  const [categoryName, setCategoryName] = useState<string | undefined>(
-    undefined
-  );
   const [year, setYear] = useState<number | undefined>(undefined);
 
-  const search = (categoryId: number, categoryName: string, year: number) => {
+  const search = (categoryId: number, year: number) => {
     props.setAwardData(undefined);
-    getAwardDataWithRetry(categoryName, year)
+    getAwardDataWithRetry(categoryId, year)
       .then(props.setAwardData)
       .catch(() => {});
   };
 
   const randomizeForm = () => {
-    randomize().then(([randomCategoryId, randomCategoryName, randomYear]) => {
-      setCategoryName(randomCategoryName);
+    randomize().then(([randomCategoryId, randomYear]) => {
+      setCategoryId(randomCategoryId);
       setYear(randomYear);
-      search(randomCategoryId, randomCategoryName, randomYear);
+      search(randomCategoryId, randomYear);
     });
   };
   return (
@@ -33,10 +30,8 @@ export function UserInputSection(props: {
         <CategorySelect categoryId={categoryId} setCategoryId={setCategoryId} />
         <YearInput year={year} setYear={setYear} />
         <button
-          onClick={() =>
-            search(categoryId as number, categoryName as string, year as number)
-          }
-          disabled={!categoryName || !year}
+          onClick={() => search(categoryId as number, year as number)}
+          disabled={!categoryId || !year}
         >
           <IconButtonLabel label="Search" icon={BsSearch} />
         </button>

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -3,14 +3,20 @@ import { BsSearch, BsShuffle } from 'react-icons/bs';
 import React, { useState } from 'react';
 import { getAwardDataWithRetry, randomize } from './Local.connector';
 import { OscarCategory } from './Models';
+import { useNavigate } from 'react-router-dom';
 
 export function UserInputSection(props: {
   setAwardData: React.Dispatch<React.SetStateAction<OscarCategory | undefined>>;
 }) {
   const [categoryId, setCategoryId] = useState<number | undefined>(undefined);
   const [year, setYear] = useState<number | undefined>(undefined);
+  const navigate = useNavigate();
 
   const search = (categoryId: number, year: number) => {
+    navigate({
+      pathname: '/',
+      search: `?category=${categoryId}&year=${year}`,
+    });
     props.setAwardData(undefined);
     getAwardDataWithRetry(categoryId, year)
       .then(props.setAwardData)

--- a/src/UserInputSection.tsx
+++ b/src/UserInputSection.tsx
@@ -30,10 +30,7 @@ export function UserInputSection(props: {
   return (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <CategorySelect
-          categoryName={categoryName}
-          setCategory={setCategoryName}
-        />
+        <CategorySelect categoryId={categoryId} setCategoryId={setCategoryId} />
         <YearInput year={year} setYear={setYear} />
         <button
           onClick={() =>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
As proposed in #4

- When the user searches for a category and year, these are saved as URL query parameters in the form of `?category=1&year=1929`
- If the user refreshes the page with query params or sends the link to someone else, the site will load with that category and year selected in the dropdown and the correct results showing.
- User can click the title in the top to navigate to the homepage and strip out their query params
- If user opens the site with no query params, it uses Best Picture as the default category

Behind the scenes:

- Searching and client-side state is tracked using `category_id` instead of `normalized_name`
- `key` props for `EnrichedLink`s to fix console error